### PR TITLE
EM-43: Add allowFullScreen attribute to iframe

### DIFF
--- a/src/components/AppWrapper/App/IFrame/__snapshots__/index.test.js.snap
+++ b/src/components/AppWrapper/App/IFrame/__snapshots__/index.test.js.snap
@@ -10,6 +10,7 @@ preact-render-spy (1 nodes)
   title="Nic Support Chat"
   onLoad={[Function bound ]}
   tabIndex={-1}
+  allowFullScreen={true}
 >
 </iframe>
 

--- a/src/components/AppWrapper/App/IFrame/index.test.js
+++ b/src/components/AppWrapper/App/IFrame/index.test.js
@@ -35,4 +35,9 @@ describe("<IFrame />", () => {
 
     expect(PRSWrapper).toMatchSnapshot();
   });
+
+  it("should have the attribute allowFullScreen set to true", () => {
+    const { PRSWrapper } = setup();
+    expect(PRSWrapper.find(".ada-embed-iframe").attr("allowFullScreen")).toBeTruthy();
+  });
 });

--- a/src/components/AppWrapper/App/IFrame/index.tsx
+++ b/src/components/AppWrapper/App/IFrame/index.tsx
@@ -72,6 +72,7 @@ export default class IFrame extends Component<InterfaceIFrame> {
         onLoad={this.onLoad}
         ref={this.handleSetRef}
         tabIndex={isDrawerOpen ? 0 : -1}
+        allowFullScreen={true}
       />
     );
   }


### PR DESCRIPTION
### Description of What has Changed
For HTML5 videos inside a cross-origin iFrame, the open in full screen button is greyed out. This branch adds the required iFrame permissions to open the video in full screen.

### Why this is Important
Needed for the Boston Globe.

### How to Test
- Create a new Video Answer with an mp4 (you can use this one: https://zippy.gfycat.com/SlipperyDefiantAndeancockoftherock.mp4)
- Trigger the answer from inside the Embed iframe. The HTML5 video should have the option to go full screen.

---
- [x] PR title follows the format \<Jira Card\>: \<Change description\>
- [x] PR description present and accurate
- [x] PR is linked to a Jira card has `impact` field filled in
- [x] Unit tests cover code changes
- [x] Changes have been tested on staging `embed-testing.svc.ada.support` site
- [ ] Changes have gone through design review if required
- [ ] Deployment plan and/or bridge code description is included in PR if required
- [x] Changes are CATO/WCAG compliant and support IE10+
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master
