### PR TITLE
BUIL-144: Receive message to reset chat

### DIFF
--- a/src/components/AppWrapper/App/index.tsx
+++ b/src/components/AppWrapper/App/index.tsx
@@ -175,19 +175,7 @@ export default class App extends Component<InterfaceApp> {
       store(client, CHATTER_ZD_SESSION, zdSession);
       this.chatterZDSession = zdSession;
     } else if (resetChat) {
-      const resetEvent = new CustomEvent(
-        "ada-event-reset",
-        {
-          detail: {
-            type: ADA_EVENT_RESET,
-            data: { metaFields }
-          },
-          bubbles: true,
-          cancelable: true
-        }
-      );
-
-      this.handleAdaEvent(resetEvent);
+      this.resetChat({ metaFields });
     }
 
     if (created) {
@@ -412,35 +400,7 @@ export default class App extends Component<InterfaceApp> {
           return;
 
         case ADA_EVENT_RESET:
-          const {
-            resetChatHistory = true,
-            metaFields = {},
-            language = "",
-            greeting = ""
-          } = data || {};
-
-          // Remove the stored chatter info
-          this.clearChatterInfo();
-
-          /**
-           * In order to reset Chat we need to remove the IFrame component and re-render it.
-           * To do this, we set `forceIFrameReRender` to `false`, then immediately back to `true`.
-           * We can simulatenously set new values for language, greeting, and metaFields.
-           */
-          this.props.setAppState({
-            language,
-            greeting,
-            metaFields,
-            resetChatHistory,
-            forceIFrameReRender: false
-          }, () => {
-            // Need to reset the chatURL before we re-open to ensure new query params are set
-            this.setChatURL();
-
-            this.props.setAppState({
-              forceIFrameReRender: true
-            });
-          });
+          this.resetChat(data);
           return;
 
         case ADA_EVENT_GET_INFO:
@@ -593,6 +553,46 @@ export default class App extends Component<InterfaceApp> {
           }
         }
       }
+    });
+  }
+
+  /**
+   * Reset the chat
+   */
+  resetChat(data: {
+    resetChatHistory?: Boolean,
+    metaFields?: object,
+    language?: String,
+    greeting?: String
+  }) {
+    const {
+      resetChatHistory = true,
+      metaFields = {},
+      language = "",
+      greeting = ""
+    } = data || {};
+
+    // Remove the stored chatter info
+    this.clearChatterInfo();
+
+    /**
+     * In order to reset Chat we need to remove the IFrame component and re-render it.
+     * To do this, we set `forceIFrameReRender` to `false`, then immediately back to `true`.
+     * We can simulatenously set new values for language, greeting, and metaFields.
+     */
+    this.props.setAppState({
+      language,
+      greeting,
+      metaFields,
+      resetChatHistory,
+      forceIFrameReRender: false
+    }, () => {
+      // Need to reset the chatURL before we re-open to ensure new query params are set
+      this.setChatURL();
+
+      this.props.setAppState({
+        forceIFrameReRender: true
+      });
     });
   }
 

--- a/src/components/AppWrapper/App/index.tsx
+++ b/src/components/AppWrapper/App/index.tsx
@@ -127,7 +127,7 @@ export default class App extends Component<InterfaceApp> {
    * Handle incoming post message events from Chat
    */
   receiveMessage(event: MessageEvent) {
-    const { client, chatURL } = this.props;
+    const { client, chatURL, metaFields } = this.props;
 
     // Ensure that event origin is the same as the Chat URL
     if (chatURL && !chatURL.startsWith(event.origin)) { return; }
@@ -141,7 +141,8 @@ export default class App extends Component<InterfaceApp> {
       chatterIds,
       newMessages,
       created,
-      zdSession
+      zdSession,
+      resetChat
     } = event.data;
 
     const {
@@ -173,6 +174,20 @@ export default class App extends Component<InterfaceApp> {
     } else if (zdSession) {
       store(client, CHATTER_ZD_SESSION, zdSession);
       this.chatterZDSession = zdSession;
+    } else if (resetChat) {
+      const resetEvent = new CustomEvent(
+        "ada-event-reset",
+        {
+          detail: {
+            type: ADA_EVENT_RESET,
+            data: { metaFields }
+          },
+          bubbles: true,
+          cancelable: true
+        }
+      );
+
+      this.handleAdaEvent(resetEvent);
     }
 
     if (created) {


### PR DESCRIPTION
### Description of What has Changed
Adds a case to `receiveMessage` that handles a `postMessage` from `chat` triggering a reset of the chat.

### Why this is Important
Part of the test bot improvements is a reset button in `chat`.

### How to Test
check out `lo-test-answer-button` in `app` and `lo-trigger-answer` in `chat`. Turn on the `embed_test_bot` feature. Click "Test Bot" in `app`. Now you'll see the new NavBar in chat, which has the reset button.

### Deployment Plan
This will go out first.

---
- [x] PR title follows the format \<Jira Card\>: \<Change description\>
- [x] PR description present and accurate
- [x] PR is linked to a Jira card has `impact` field filled in
- [ ] Unit tests cover code changes
- [ ] Changes have been tested on staging `embed-testing.svc.ada.support` site
- [x] Changes have gone through design review if required
- [x] Deployment plan and/or bridge code description is included in PR if required
- [ ] Changes are CATO/WCAG compliant and support IE10+
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master
