### PR TITLE
EM-87: Add Embed identifer

### DIFF
--- a/src/services/__tests__/constructURL.test.js
+++ b/src/services/__tests__/constructURL.test.js
@@ -69,7 +69,7 @@ describe("constructURL", () => {
       route: "chatters"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/chatters/");
+    expect(url).toBe("https://nic.ada.support/chat/chatters/?embed=1");
   });
 
   it("should set language in the query string if specified", () => {
@@ -89,7 +89,7 @@ describe("constructURL", () => {
       privateMode: true,
       greeting: "123"
     }, false);
-    expect(url.match(/&/g).length).toBe(2);
+    expect(url.match(/&/g).length).toBe(3);
     expect(url.match(/\?/g).length).toBe(1);
   });
 
@@ -102,15 +102,15 @@ describe("constructURL", () => {
       }
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/?test1=yolo&test2=yodo");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1&test1=yolo&test2=yodo");
   });
 
-  it("should not include metaFields if undefined", () => {
+  it("should not include metaFields if undefined (except for embed)", () => {
     const url = constructURL({
       handle: "nic"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1");
   });
 
   it("should add followUpResponseId to URL if provided", () => {
@@ -119,7 +119,7 @@ describe("constructURL", () => {
       followUpResponseId: "123"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/?followUpResponseId=123");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1&followUpResponseId=123");
   });
 
   it("should include the greeting id in the Chat URL if specified in adaSettings", () => {
@@ -128,7 +128,7 @@ describe("constructURL", () => {
       greeting: "123"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/?greeting=123");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1&greeting=123");
   });
 });
 

--- a/src/services/constructURL.ts
+++ b/src/services/constructURL.ts
@@ -67,11 +67,13 @@ export default function constructURL(
     const chatterTokenString = chatterToken ? `chatterToken=${chatterToken}` : undefined;
     const chatterCreatedString = chatterCreated ? `created=${chatterCreated}` : undefined;
     const chatterZDSessionString = chatterZDSession ? `zdSession=${chatterZDSession}` : undefined;
+    const embedString = "embed=1"; // This tells us Chat was setup with Embed, not Chaperone
     const followUpResponseIdString = followUpResponseId ?
       `followUpResponseId=${followUpResponseId}` : undefined;
 
     queryString = [
       resetMode,
+      embedString,
       newPrivateMode,
       greetingString,
       languageString,


### PR DESCRIPTION
### Description of What has Changed
We now pass an identifier, `embed=1`, as a query parameter to Chat. This let's chat know that Embed (and not Chaperone) is being used. This information will be used by Chat to help prevent "garbage" meta variables being sent by chrome extensions.

### Why this is Important
Upwork (and other clients) are having their meta variables contaminated with garbage meta variables.

### How to Test
Verify that `embed=1` is added as a query parameter.

### Deployment Plan
This should be deployed after Chat https://github.com/AdaSupport/chat/pull/858.

---
- [ ] PR title follows the format \<Jira Card\>: \<Change description\>
- [ ] PR description present and accurate
- [ ] PR is linked to a Jira card has `impact` field filled in
- [ ] Unit tests cover code changes
- [ ] Changes have been tested on staging `embed-testing.svc.ada.support` site
- [ ] Changes have gone through design review if required
- [ ] Deployment plan and/or bridge code description is included in PR if required
- [ ] Changes are CATO/WCAG compliant and support IE10+
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master
