### PR TITLE
Merge beta in master (#146)

### DIFF
--- a/src/services/__tests__/constructURL.test.js
+++ b/src/services/__tests__/constructURL.test.js
@@ -69,7 +69,7 @@ describe("constructURL", () => {
       route: "chatters"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/chatters/");
+    expect(url).toBe("https://nic.ada.support/chat/chatters/?embed=1");
   });
 
   it("should set language in the query string if specified", () => {
@@ -89,7 +89,7 @@ describe("constructURL", () => {
       privateMode: true,
       greeting: "123"
     }, false);
-    expect(url.match(/&/g).length).toBe(2);
+    expect(url.match(/&/g).length).toBe(3);
     expect(url.match(/\?/g).length).toBe(1);
   });
 
@@ -102,15 +102,15 @@ describe("constructURL", () => {
       }
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/?test1=yolo&test2=yodo");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1&test1=yolo&test2=yodo");
   });
 
-  it("should not include metaFields if undefined", () => {
+  it("should not include metaFields if undefined (except for embed)", () => {
     const url = constructURL({
       handle: "nic"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1");
   });
 
   it("should add followUpResponseId to URL if provided", () => {
@@ -119,7 +119,7 @@ describe("constructURL", () => {
       followUpResponseId: "123"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/?followUpResponseId=123");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1&followUpResponseId=123");
   });
 
   it("should include the greeting id in the Chat URL if specified in adaSettings", () => {
@@ -128,7 +128,7 @@ describe("constructURL", () => {
       greeting: "123"
     }, false);
 
-    expect(url).toBe("https://nic.ada.support/chat/?greeting=123");
+    expect(url).toBe("https://nic.ada.support/chat/?embed=1&greeting=123");
   });
 });
 

--- a/src/services/constructURL.ts
+++ b/src/services/constructURL.ts
@@ -67,11 +67,13 @@ export default function constructURL(
     const chatterTokenString = chatterToken ? `chatterToken=${chatterToken}` : undefined;
     const chatterCreatedString = chatterCreated ? `created=${chatterCreated}` : undefined;
     const chatterZDSessionString = chatterZDSession ? `zdSession=${chatterZDSession}` : undefined;
+    const embedString = "embed=1"; // This tells us Chat was setup with Embed, not Chaperone
     const followUpResponseIdString = followUpResponseId ?
       `followUpResponseId=${followUpResponseId}` : undefined;
 
     queryString = [
       resetMode,
+      embedString,
       newPrivateMode,
       greetingString,
       languageString,


### PR DESCRIPTION
* fixed tabbing navigation bug when blurb is closed

* FND-1181: Be able to point to different clusters/bots when testing (#109)

* init

* revert test

* refactor

* touch

* rename

* update README

* typo

* Nic's Comments

* added tests

* newline

* no message

* Release beta (#102) (#110)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Rename customStyles to styles (#38)

* Remove references to customStyles

* Merge Beta into Master (#37)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Bug fix for metaFields on mobile (#40)

* FND-856: Make mask overlay configurable (#42)

* Suppress mask if hideMask is true

* Add a test for hiding the mask

* Update PR template

* Fix link in PR template

* FND-862: Follow Up Responses for Mobile (#44)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Deconstruct props and fix tests

* FND-875: Set meta fields in the Chat URL (#46)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Add metaFields to URL for chat if available

* Don't send metaFields by postMessage anymore when iFrame loads

* FND-874: Deprecate "greetingHandle" for "greeting" (#47)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Put the greeting in the URL

* Fix and add tests

* Add another test

* Match Client Branding (#18)

* Improve contructURL

* Bug fix to constructURL

* wip - setting up parentElement functionality

* setting up parentElement

* Render iFrame into parentElement

* Copy rollout functions into Chaperon2 from Chaperone1

* WIP - setting up rollout

* Create Client model

* Chaperone UI renders based on rollout

* Cleanup rollout

* Hide chat button when drawer is opened

* Add color to button

* WIP - exploring best ways to pass props to widget

* Converted index.js to index.ts

* wip - creating adaEmbedBoot function

* Setup postMessage event listeners

* WIP - setting up metafields

* Render iFrame component into customFrame

* Setting up postMessage triggers

* Send postMessage to Chat

* wip - sending postMessage payload

* Improve prop passing

* wip

* Setup followUpResponseId

* wip - setting up intros

* Animate intro text in and out

* Can dismiss intro

* Intro message is clickable

* Update styling

* Style grooming for intros text

* Get intro emoji to show up

* Only show emoji intro if drawer has not been opened

* Do not show intro blurb if drawer has been opened

* wip - cleaning up stylesheets

* WIP - creating a more intuitive way to interact with the bot

* Refactor event listeners

* Fix merge issue

* Set IFrame ref in the parent component

* Add more event types to Ada function

* Create constants for event names

* Focus iFrame when chat opened

* Fix linting issues inside src/index.ts

* Adds chat button to client model and att background color to button

* wip - setting up snapshot tests

* Fix issue with window navigator in tests

* Renamed env to env.example and added env to ignore

* Local dev now uses local api and chat

* Adds size update to chat button

* Adds functionality for chat button to reflect the one set in settings

* Setup Preact with Enzyme

* Cleanup to App/index

* Store chatURL and APIURL in constructor to prevent triggering constructUrl

* Add more comments

* Wrote tests for checkRollout

* Wrote test for capitalize service

* Minor cleanup

* Write tests for constructURL

* wip

* Swap out enzyme for preact-render-spy

* Add tests for parentElement

* Add snapshot tests to remaining components

* Add tests to button component

* Add a test for hiding the default chat icon

* Add tests for Drawer

* Cleanup IFrame

* Add tests for IntroBlurb

* Fix issue where couldn't set meta data for parentElement iframes

* Inlclude metaFields in postMessage, namespace to send

* Update lint config

* Put the meta fields in the query string of the chat window

* Add list of reserved words for query string creation

* Add tests for constructURL

* Updated tests

* Update based on feedback

* Just testing things

* Updates intro bubble for larger chat buttons

* Updates constant and reverts env.example

* reverts yarn lock

* Use inline svg

* Removes unused var

* Code review updates and tests

* Fixes intro blurb positioning

* Fixes size ratio

* Cleans up padding style

* Updates test

* Updates snapshot

* FND-898, FND-900: Toggle Fix & Make Mobile Overlay on by Default (#51)

* Fix toggle issue, make mobileOverlay true default

* Update snapshot

* Remove mobileOverlay option

* HOTFIX: Zendesk Blink (#54)

* Add showZendeskWidget function

* Fix toggle for closing embed after zendesk handoff

* EX-1161: Notification Badge for Embed (#49)

* Added notification icon to button comp

* Added route to URL constructor

* Added notification icon to button comp

* Make call to connect on chat and retreve chatter id and make api call for unread amount

* Invert bool statement

* Small fix and animation fix

* Added handling for new messages

* Add API call to clear and auto load chat if in live_state

* Update tests

* Add constructURL tests

* Add tests

* Store chatter when chat does a pass back in the case chatter is newly created

* Add alt and role to badge

* Fix persistence issue

* Fix issues

* Allow scalling of badge based on client button size

* Change to chatterIds and styling fixes

* Fix ratios to better get a cirlce

* Round the height and width to properly center the badge

* FND-819, FND-904: Overlay and Intros Improvements (#52)

* iPad should not be considered mobile

* Fix z-index on intro

* HOTFIX: custom events (#58)

* Make #ada-embed element available in synchronous flow

* Resolve event listener issues

* Cleanup and update snapshots

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Removed duplicate id

* Fix snapshot

* Fix spacing

* FND-889: CATO Test and minor fixes (#53)

* arrange intros in logical tab order

* FND-889 : test and cato fixes

* Add CODEOWNERS, move PULL_REQUEST_TEMPLATE into .github directory (#60)

* set version to 11.10 (#63)

* FND-958, FND-959: Bug Fixes (#65)

* Ensure that embed container takes up full height in parent element

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Remove height 100% (#67)

* FND-966: Fix for parent element height (#70)

* Add height 100% if inside iFrame

* Add a test

* Add a test

* FND-915: Add Sentry Logging (#62)

* yarn add @sentry/browser@4.6.4

* create env var and initialize sentry

* add reference to env variables

* manually capture exception

* add a source tag to loggings

* move const higher

* fix conflicts

* FND-915: Whitelist URL in Sentry (#73)

* wip: whitelisting

* clean up

* remove console.log

* fix spacing

* Revert to 8d0a59d726ee3c0a0f74a81baa807a3d9a195b8b

* FND-981: adaEmbed.start() on ready (#77)

* FND-915: Add Sentry Logging (#72)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Rename customStyles to styles (#38)

* Remove references to customStyles

* Merge Beta into Master (#37)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Bug fix for metaFields on mobile (#40)

* FND-856: Make mask overlay configurable (#42)

* Suppress mask if hideMask is true

* Add a test for hiding the mask

* Update PR template

* Fix link in PR template

* FND-862: Follow Up Responses for Mobile (#44)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Deconstruct props and fix tests

* FND-875: Set meta fields in the Chat URL (#46)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Add metaFields to URL for chat if available

* Don't send metaFields by postMessage anymore when iFrame loads

* FND-874: Deprecate "greetingHandle" for "greeting" (#47)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Put the greeting in the URL

* Fix and add tests

* Add another test

* Match Client Branding (#18)

* Improve contructURL

* Bug fix to constructURL

* wip - setting up parentElement functionality

* setting up parentElement

* Render iFrame into parentElement

* Copy rollout functions into Chaperon2 from Chaperone1

* WIP - setting up rollout

* Create Client model

* Chaperone UI renders based on rollout

* Cleanup rollout

* Hide chat button when drawer is opened

* Add color to button

* WIP - exploring best ways to pass props to widget

* Converted index.js to index.ts

* wip - creating adaEmbedBoot function

* Setup postMessage event listeners

* WIP - setting up metafields

* Render iFrame component into customFrame

* Setting up postMessage triggers

* Send postMessage to Chat

* wip - sending postMessage payload

* Improve prop passing

* wip

* Setup followUpResponseId

* wip - setting up intros

* Animate intro text in and out

* Can dismiss intro

* Intro message is clickable

* Update styling

* Style grooming for intros text

* Get intro emoji to show up

* Only show emoji intro if drawer has not been opened

* Do not show intro blurb if drawer has been opened

* wip - cleaning up stylesheets

* WIP - creating a more intuitive way to interact with the bot

* Refactor event listeners

* Fix merge issue

* Set IFrame ref in the parent component

* Add more event types to Ada function

* Create constants for event names

* Focus iFrame when chat opened

* Fix linting issues inside src/index.ts

* Adds chat button to client model and att background color to button

* wip - setting up snapshot tests

* Fix issue with window navigator in tests

* Renamed env to env.example and added env to ignore

* Local dev now uses local api and chat

* Adds size update to chat button

* Adds functionality for chat button to reflect the one set in settings

* Setup Preact with Enzyme

* Cleanup to App/index

* Store chatURL and APIURL in constructor to prevent triggering constructUrl

* Add more comments

* Wrote tests for checkRollout

* Wrote test for capitalize service

* Minor cleanup

* Write tests for constructURL

* wip

* Swap out enzyme for preact-render-spy

* Add tests for parentElement

* Add snapshot tests to remaining components

* Add tests to button component

* Add a test for hiding the default chat icon

* Add tests for Drawer

* Cleanup IFrame

* Add tests for IntroBlurb

* Fix issue where couldn't set meta data for parentElement iframes

* Inlclude metaFields in postMessage, namespace to send

* Update lint config

* Put the meta fields in the query string of the chat window

* Add list of reserved words for query string creation

* Add tests for constructURL

* Updated tests

* Update based on feedback

* Just testing things

* Updates intro bubble for larger chat buttons

* Updates constant and reverts env.example

* reverts yarn lock

* Use inline svg

* Removes unused var

* Code review updates and tests

* Fixes intro blurb positioning

* Fixes size ratio

* Cleans up padding style

* Updates test

* Updates snapshot

* FND-898, FND-900: Toggle Fix & Make Mobile Overlay on by Default (#51)

* Fix toggle issue, make mobileOverlay true default

* Update snapshot

* Remove mobileOverlay option

* HOTFIX: Zendesk Blink (#54)

* Add showZendeskWidget function

* Fix toggle for closing embed after zendesk handoff

* EX-1161: Notification Badge for Embed (#49)

* Added notification icon to button comp

* Added route to URL constructor

* Added notification icon to button comp

* Make call to connect on chat and retreve chatter id and make api call for unread amount

* Invert bool statement

* Small fix and animation fix

* Added handling for new messages

* Add API call to clear and auto load chat if in live_state

* Update tests

* Add constructURL tests

* Add tests

* Store chatter when chat does a pass back in the case chatter is newly created

* Add alt and role to badge

* Fix persistence issue

* Fix issues

* Allow scalling of badge based on client button size

* Change to chatterIds and styling fixes

* Fix ratios to better get a cirlce

* Round the height and width to properly center the badge

* FND-819, FND-904: Overlay and Intros Improvements (#52)

* iPad should not be considered mobile

* Fix z-index on intro

* HOTFIX: custom events (#58)

* Make #ada-embed element available in synchronous flow

* Resolve event listener issues

* Cleanup and update snapshots

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Removed duplicate id

* Fix snapshot

* Fix spacing

* FND-889: CATO Test and minor fixes (#53)

* arrange intros in logical tab order

* FND-889 : test and cato fixes

* Add CODEOWNERS, move PULL_REQUEST_TEMPLATE into .github directory (#60)

* set version to 11.10 (#63)

* FND-958, FND-959: Bug Fixes (#65)

* Ensure that embed container takes up full height in parent element

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Remove height 100% (#67)

* FND-966: Fix for parent element height (#70)

* Add height 100% if inside iFrame

* Add a test

* Add a test

* FND-915: Add Sentry Logging (#62)

* yarn add @sentry/browser@4.6.4

* create env var and initialize sentry

* add reference to env variables

* manually capture exception

* add a source tag to loggings

* move const higher

* fix conflicts

* Revert "FND-915: Add Sentry Logging (#72)"

This reverts commit d4ddbc1aad5162f3de0bc90f507541bb79740c06.

* FND-915: Whitelist URL in Sentry (#74)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Rename customStyles to styles (#38)

* Remove references to customStyles

* Merge Beta into Master (#37)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Bug fix for metaFields on mobile (#40)

* FND-856: Make mask overlay configurable (#42)

* Suppress mask if hideMask is true

* Add a test for hiding the mask

* Update PR template

* Fix link in PR template

* FND-862: Follow Up Responses for Mobile (#44)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Deconstruct props and fix tests

* FND-875: Set meta fields in the Chat URL (#46)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Add metaFields to URL for chat if available

* Don't send metaFields by postMessage anymore when iFrame loads

* FND-874: Deprecate "greetingHandle" for "greeting" (#47)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Put the greeting in the URL

* Fix and add tests

* Add another test

* Match Client Branding (#18)

* Improve contructURL

* Bug fix to constructURL

* wip - setting up parentElement functionality

* setting up parentElement

* Render iFrame into parentElement

* Copy rollout functions into Chaperon2 from Chaperone1

* WIP - setting up rollout

* Create Client model

* Chaperone UI renders based on rollout

* Cleanup rollout

* Hide chat button when drawer is opened

* Add color to button

* WIP - exploring best ways to pass props to widget

* Converted index.js to index.ts

* wip - creating adaEmbedBoot function

* Setup postMessage event listeners

* WIP - setting up metafields

* Render iFrame component into customFrame

* Setting up postMessage triggers

* Send postMessage to Chat

* wip - sending postMessage payload

* Improve prop passing

* wip

* Setup followUpResponseId

* wip - setting up intros

* Animate intro text in and out

* Can dismiss intro

* Intro message is clickable

* Update styling

* Style grooming for intros text

* Get intro emoji to show up

* Only show emoji intro if drawer has not been opened

* Do not show intro blurb if drawer has been opened

* wip - cleaning up stylesheets

* WIP - creating a more intuitive way to interact with the bot

* Refactor event listeners

* Fix merge issue

* Set IFrame ref in the parent component

* Add more event types to Ada function

* Create constants for event names

* Focus iFrame when chat opened

* Fix linting issues inside src/index.ts

* Adds chat button to client model and att background color to button

* wip - setting up snapshot tests

* Fix issue with window navigator in tests

* Renamed env to env.example and added env to ignore

* Local dev now uses local api and chat

* Adds size update to chat button

* Adds functionality for chat button to reflect the one set in settings

* Setup Preact with Enzyme

* Cleanup to App/index

* Store chatURL and APIURL in constructor to prevent triggering constructUrl

* Add more comments

* Wrote tests for checkRollout

* Wrote test for capitalize service

* Minor cleanup

* Write tests for constructURL

* wip

* Swap out enzyme for preact-render-spy

* Add tests for parentElement

* Add snapshot tests to remaining components

* Add tests to button component

* Add a test for hiding the default chat icon

* Add tests for Drawer

* Cleanup IFrame

* Add tests for IntroBlurb

* Fix issue where couldn't set meta data for parentElement iframes

* Inlclude metaFields in postMessage, namespace to send

* Update lint config

* Put the meta fields in the query string of the chat window

* Add list of reserved words for query string creation

* Add tests for constructURL

* Updated tests

* Update based on feedback

* Just testing things

* Updates intro bubble for larger chat buttons

* Updates constant and reverts env.example

* reverts yarn lock

* Use inline svg

* Removes unused var

* Code review updates and tests

* Fixes intro blurb positioning

* Fixes size ratio

* Cleans up padding style

* Updates test

* Updates snapshot

* FND-898, FND-900: Toggle Fix & Make Mobile Overlay on by Default (#51)

* Fix toggle issue, make mobileOverlay true default

* Update snapshot

* Remove mobileOverlay option

* HOTFIX: Zendesk Blink (#54)

* Add showZendeskWidget function

* Fix toggle for closing embed after zendesk handoff

* EX-1161: Notification Badge for Embed (#49)

* Added notification icon to button comp

* Added route to URL constructor

* Added notification icon to button comp

* Make call to connect on chat and retreve chatter id and make api call for unread amount

* Invert bool statement

* Small fix and animation fix

* Added handling for new messages

* Add API call to clear and auto load chat if in live_state

* Update tests

* Add constructURL tests

* Add tests

* Store chatter when chat does a pass back in the case chatter is newly created

* Add alt and role to badge

* Fix persistence issue

* Fix issues

* Allow scalling of badge based on client button size

* Change to chatterIds and styling fixes

* Fix ratios to better get a cirlce

* Round the height and width to properly center the badge

* FND-819, FND-904: Overlay and Intros Improvements (#52)

* iPad should not be considered mobile

* Fix z-index on intro

* HOTFIX: custom events (#58)

* Make #ada-embed element available in synchronous flow

* Resolve event listener issues

* Cleanup and update snapshots

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Removed duplicate id

* Fix snapshot

* Fix spacing

* FND-889: CATO Test and minor fixes (#53)

* arrange intros in logical tab order

* FND-889 : test and cato fixes

* Add CODEOWNERS, move PULL_REQUEST_TEMPLATE into .github directory (#60)

* set version to 11.10 (#63)

* FND-958, FND-959: Bug Fixes (#65)

* Ensure that embed container takes up full height in parent element

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Remove height 100% (#67)

* FND-966: Fix for parent element height (#70)

* Add height 100% if inside iFrame

* Add a test

* Add a test

* FND-915: Add Sentry Logging (#62)

* yarn add @sentry/browser@4.6.4

* create env var and initialize sentry

* add reference to env variables

* manually capture exception

* add a source tag to loggings

* move const higher

* fix conflicts

* FND-915: Whitelist URL in Sentry (#73)

* wip: whitelisting

* clean up

* remove console.log

* fix spacing

* Auto start after DOM has loaded

* Revert "FND-915: Whitelist URL in Sentry (#74)" (#75)

This reverts commit 21622a03e2c4b3737c2196eed99a4744300c3b98.

* Add comments

* Cleanup testing page

* Replace includes with indexOf for IE

* Add a comment fro IE9 script placement

* Add an important to mask background colour to prevent style clobbering on uplift (#79)

* FND-980: Prevent multiple start/stop calls (#82)

* Prevent start and stopping multiple consecutive times

* Create a method to return the ada-embed element

* Minor refactor

* FND-1002: Quick fix change to CircleCI (#84)

* Quick fix change to CIrcleCI
supporting a new branch for quick fix deployment and testing

* typo

* typo

* FND-984: Fixes SVG blinking while it loads (#80)

* Fixes blinking

* Linting

* FND-992: IE Support for Custom Events (#86)

* WIP - validate custom events work

* Refactoring

* FND-1006: Fixes default lang for intros URL (#85)

* Fixes default lang for intros URL

* Removes console.log

* Fixes translation.js and update tests

* Updates translation service

* Disables tslint for string property access

* adds newline

* Adds Navigator Type

* Inject styles thru <style> tag instead of link with blob: (#88)

* Inject styles thru <style> tag instead of link with blob:

* Don't turn on sourceMaps for postcss

* Update preact-beta.config (#89)

* Delete CODEOWNERS

* Add cluster to connector URL (#92)

* INT-319: Introduce Drag and Drop to Embed (#91)

* Add Draggable class

* Switch to no parentElement

* Use Draggable

* Remember location after chat is opened

* Simplify calculations

* Loop through each child and push props

* Remove import

* Fix Draggable issues

* Fix Button styles and switching

* Fix Intro styles and switching

* Use draggability HOC and switch between draggable

* Add dragAndDrop to test page

* Remove console log

* Update snapshots

* Add Button tests

* Fix conditional

* Add Intro tests

* Limit bounds on left and bottom

* Remove console log

* Add support for mobile

* Add outline handler

* Suppress capture event from going down

* Remove beingDragged

* Update tests

* Address comments

* Contants file

* Show button when drag and drop is turned on

* Fix iOS issues

* Address comments

* MEAS-426: Web interactions: send intro and url info to chatter endpoint (#94)

* MEAS-426: Web interactions: send intro and url info to chatter endpoint

* MEAS-426: Update snapshot

* MEAS-426: Create a separate introShown state property

* BT-599: Fixes iOS scrolling issues (#95)

* Fixes iOS scrolling issues

* removes bind. Unnecessary

* Remeber previous overflow state

* lock only on mobile (#96)

* Bm lock only on mobile (#97)

* lock only on mobile

* Adds body-lock-scroll

* HOTFIX--Resolve iOS scrolling issues (#99)

* wip

* implement new fix using position fixed

* Cleanup

* MEAS-445: Make chatURL a dynamic getter. Send introShown param (#101)

* MEAS-445: Make chatURL a dynamic getter. Sent introShown param

* MEAS-445: Sent initialURL param

* MEAS-445: Update snapshot

* MEAS-445: Rename url attr to initialURL

* MEAS-445: Oups

* init (#112)

* Master into beta (#114)

* Release beta (#102)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Rename customStyles to styles (#38)

* Remove references to customStyles

* Merge Beta into Master (#37)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* FND-841: Fix tabbing issue (#34)

* Merge beta into master (#33)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* Cleanup codestyle

* wip - improving httpRequest

* Fix issue where IE9 wasn't working

* Resolve issue where IE9 aborts requests

* Fix tabbing issue and blur modal on close

* Add tests

* Rename Chaperone to Embed (#36)

* Rename chaperone to embed everywhere

* Naming fix

* Bug fix for metaFields on mobile (#40)

* FND-856: Make mask overlay configurable (#42)

* Suppress mask if hideMask is true

* Add a test for hiding the mask

* Update PR template

* Fix link in PR template

* FND-862: Follow Up Responses for Mobile (#44)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Deconstruct props and fix tests

* FND-875: Set meta fields in the Chat URL (#46)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Add metaFields to URL for chat if available

* Don't send metaFields by postMessage anymore when iFrame loads

* FND-874: Deprecate "greetingHandle" for "greeting" (#47)

* Add followUpResponseId to the query string instead of sending by postMessage

* Cleanup

* Add a test for followUpResponseId

* Put the greeting in the URL

* Fix and add tests

* Add another test

* Match Client Branding (#18)

* Improve contructURL

* Bug fix to constructURL

* wip - setting up parentElement functionality

* setting up parentElement

* Render iFrame into parentElement

* Copy rollout functions into Chaperon2 from Chaperone1

* WIP - setting up rollout

* Create Client model

* Chaperone UI renders based on rollout

* Cleanup rollout

* Hide chat button when drawer is opened

* Add color to button

* WIP - exploring best ways to pass props to widget

* Converted index.js to index.ts

* wip - creating adaEmbedBoot function

* Setup postMessage event listeners

* WIP - setting up metafields

* Render iFrame component into customFrame

* Setting up postMessage triggers

* Send postMessage to Chat

* wip - sending postMessage payload

* Improve prop passing

* wip

* Setup followUpResponseId

* wip - setting up intros

* Animate intro text in and out

* Can dismiss intro

* Intro message is clickable

* Update styling

* Style grooming for intros text

* Get intro emoji to show up

* Only show emoji intro if drawer has not been opened

* Do not show intro blurb if drawer has been opened

* wip - cleaning up stylesheets

* WIP - creating a more intuitive way to interact with the bot

* Refactor event listeners

* Fix merge issue

* Set IFrame ref in the parent component

* Add more event types to Ada function

* Create constants for event names

* Focus iFrame when chat opened

* Fix linting issues inside src/index.ts

* Adds chat button to client model and att background color to button

* wip - setting up snapshot tests

* Fix issue with window navigator in tests

* Renamed env to env.example and added env to ignore

* Local dev now uses local api and chat

* Adds size update to chat button

* Adds functionality for chat button to reflect the one set in settings

* Setup Preact with Enzyme

* Cleanup to App/index

* Store chatURL and APIURL in constructor to prevent triggering constructUrl

* Add more comments

* Wrote tests for checkRollout

* Wrote test for capitalize service

* Minor cleanup

* Write tests for constructURL

* wip

* Swap out enzyme for preact-render-spy

* Add tests for parentElement

* Add snapshot tests to remaining components

* Add tests to button component

* Add a test for hiding the default chat icon

* Add tests for Drawer

* Cleanup IFrame

* Add tests for IntroBlurb

* Fix issue where couldn't set meta data for parentElement iframes

* Inlclude metaFields in postMessage, namespace to send

* Update lint config

* Put the meta fields in the query string of the chat window

* Add list of reserved words for query string creation

* Add tests for constructURL

* Updated tests

* Update based on feedback

* Just testing things

* Updates intro bubble for larger chat buttons

* Updates constant and reverts env.example

* reverts yarn lock

* Use inline svg

* Removes unused var

* Code review updates and tests

* Fixes intro blurb positioning

* Fixes size ratio

* Cleans up padding style

* Updates test

* Updates snapshot

* FND-898, FND-900: Toggle Fix & Make Mobile Overlay on by Default (#51)

* Fix toggle issue, make mobileOverlay true default

* Update snapshot

* Remove mobileOverlay option

* HOTFIX: Zendesk Blink (#54)

* Add showZendeskWidget function

* Fix toggle for closing embed after zendesk handoff

* EX-1161: Notification Badge for Embed (#49)

* Added notification icon to button comp

* Added route to URL constructor

* Added notification icon to button comp

* Make call to connect on chat and retreve chatter id and make api call for unread amount

* Invert bool statement

* Small fix and animation fix

* Added handling for new messages

* Add API call to clear and auto load chat if in live_state

* Update tests

* Add constructURL tests

* Add tests

* Store chatter when chat does a pass back in the case chatter is newly created

* Add alt and role to badge

* Fix persistence issue

* Fix issues

* Allow scalling of badge based on client button size

* Change to chatterIds and styling fixes

* Fix ratios to better get a cirlce

* Round the height and width to properly center the badge

* FND-819, FND-904: Overlay and Intros Improvements (#52)

* iPad should not be considered mobile

* Fix z-index on intro

* HOTFIX: custom events (#58)

* Make #ada-embed element available in synchronous flow

* Resolve event listener issues

* Cleanup and update snapshots

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Removed duplicate id

* Fix snapshot

* Fix spacing

* FND-889: CATO Test and minor fixes (#53)

* arrange intros in logical tab order

* FND-889 : test and cato fixes

* Add CODEOWNERS, move PULL_REQUEST_TEMPLATE into .github directory (#60)

* set version to 11.10 (#63)

* FND-958, FND-959: Bug Fixes (#65)

* Ensure that embed container takes up full height in parent element

* Fix issue where clicking the embed button very quickly (before fetchUnread had retruned) would cause the drawer to load without the iFrame

* Remove height 100% (#67)

* FND-966: Fix for parent element height (#70)

* Add height 100% if inside iFrame

* Add a test

* Add a test

* FND-915: Add Sentry Logging (#62)

* yarn add @sentry/browser@4.6.4

* create env var and initialize sentry

* add reference to env variables

* manually capture exception

* add a source tag to loggings

* move const higher

* fix conflicts

* FND-915: Whitelist URL in Sentry (#73)

* wip: whitelisting

* clean up

* remove console.log

* fix spacing

* Revert to 8d0a59d726ee3c0a0f74a81baa807a3d9a195b8b

* FND-981: adaEmbed.start() on ready (#77)

* FND-915: Add Sentry Logging (#72)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checklist

* FND-816: Replace CSS svgs with inline SVGs (#28)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26) (#27)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Add loader for SVGs

* Replace CSS svg with inline SVG

* Fix issue where jest couldn't mock files

* FND-837: Bug fix where IFrame was not utilizing global postMessage service (#30)

* Bug fix where IFrame was not utilizing global postMessage service

* Improve setMetaFields action to reduce number of storage requests

* FND-823: script is cross-browser compatible  (#29)

* wip

* FND-823: Embed script compatible cross browser

* Merge Beta into Master (#32)

* FND-828, FND-830: Create embed ready callback, cache postMessages until ready (#26)

* Queue postmessages before iFrame is setup

* Only dispatch event if ada-mebed element is present

* Create PR checkl…

_(A screenshot of what the changes look like should go here if there are UI changes)_

### Description of What has Changed

### Why this is Important

### How to Test
> _Bullet point instructions on how to test this PR_

### Deployment Plan
> _A step by step deployment plan and any branch dependencies should be outlined here (if required)_

---
- [ ] PR title follows the format \<Jira Card\>: \<Change description\>
- [ ] PR description present and accurate
- [ ] PR is linked to a Jira card has `impact` field filled in
- [ ] Unit tests cover code changes
- [ ] Changes have been tested on staging `embed-testing.svc.ada.support` site
- [ ] Changes have gone through design review if required
- [ ] Deployment plan and/or bridge code description is included in PR if required
- [ ] Changes are CATO/WCAG compliant and support IE10+
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master
