### PR TITLE
handle javascript event callbacks for new block

### DIFF
--- a/src/components/AppWrapper/App/index.tsx
+++ b/src/components/AppWrapper/App/index.tsx
@@ -142,14 +142,16 @@ export default class App extends Component<InterfaceApp> {
       newMessages,
       created,
       zdSession,
-      resetChat
+      resetChat,
+      javascriptEvent
     } = event.data;
 
     const {
+      analyticsCallback,
+      chatterTokenCallback,
+      eventCallbacks,
       isDrawerOpen,
       liveHandoffCallback,
-      chatterTokenCallback,
-      analyticsCallback
     } = this.props;
 
     if (liveHandoff && liveHandoffCallback) {
@@ -176,6 +178,15 @@ export default class App extends Component<InterfaceApp> {
       this.chatterZDSession = zdSession;
     } else if (resetChat) {
       this.resetChat({ metaFields });
+    } else if (javascriptEvent && eventCallbacks) {
+        const specificCallback = eventCallbacks[javascriptEvent.event_name];
+        const genericCallback = eventCallbacks['*'];
+        if (specificCallback) {
+            specificCallback(javascriptEvent);
+        }
+        if (genericCallback) {
+            genericCallback(javascriptEvent);
+        }
     }
 
     if (created) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,10 @@ export interface InterfaceStartOptions {
   liveHandoffCallback?(liveHandoff: any): any,
 
   // Triggered when "chatter" postMessage event received
-  chatterTokenCallback?(chatter: string): any
+  chatterTokenCallback?(chatter: string): any,
+
+  // Triggered when "javascriptEvent" postMessage event received
+  eventCallbacks?(eventData: string): any
 }
 
 interface InterfaceResetOptions {


### PR DESCRIPTION
### Description of What has Changed
We now enable the user to setup specific callbacks for javascript events triggered by the new javascript event block.

### Why this is Important
This is a requirement for Uplfit's renewal. Also, having a custom JS event block will unlock the path to Telus-style handoffs on the web for any platform, such as Kustomer, Genesys, Freshchat, Intercom, and decrease the technical debt in the API codebase.

### How to Test
The easiest way would be to manually trigger a postMessage from the `chat` app. Can also provide instructions on how to setup full flow once I open corresponding PRs in `chat`, `app`, and `api`

### Deployment Plan
Since this feature is behind it's own feature flipper, we can deploy the updated apps in any order.

---
- [ ] PR title follows the format \<Jira Card\>: \<Change description\>
- [ ] PR description present and accurate
- [ ] PR is linked to a Jira card has `impact` field filled in
- [ ] Unit tests cover code changes
- [ ] Changes have been tested on staging `embed-testing.svc.ada.support` site
- [ ] Changes have gone through design review if required
- [ ] Deployment plan and/or bridge code description is included in PR if required
- [ ] Changes are CATO/WCAG compliant and support IE10+
- [ ] A [Release Note](https://www.notion.so/adasupport/Creating-Release-Notes-36906dfa8a2b4f10a31dc23b8d46681a) has been drafted and published after merging to master
